### PR TITLE
Allow null values for `getLabel`

### DIFF
--- a/app/code/Magento/Catalog/Block/Product/ImageFactory.php
+++ b/app/code/Magento/Catalog/Block/Product/ImageFactory.php
@@ -114,7 +114,7 @@ class ImageFactory
      * @param string $imageType
      * @return string
      */
-    private function getLabel(Product $product, string $imageType): string
+    private function getLabel(Product $product, ?string $imageType = null): string
     {
         $label = $product->getData($imageType . '_' . 'label');
         if (empty($label)) {


### PR DESCRIPTION


<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios
    Fields marked with (*) are required. Please don't remove the template.
-->

<!--- Please provide a general summary of the Pull Request in the Title above -->

### Description (*)
<!---
    Please provide a description of the changes proposed in the pull request.
    Letting us know what has changed and why it needed changing will help us validate this pull request.
-->
`\Magento\Catalog\Model\Product\Image\ParamsBuilder::build` allows to be `$miscParams['image_type']` to be `null`. Therefore `getLabel` must allow nullable types. Otherwise a Type Error occurs.



### Related Pull Requests
<!-- related pull request placeholder -->

### Fixed Issues (if relevant)
<!---
    If relevant, please provide a list of fixed issues in the format magento/magento2#<issue_number>.
    There could be 1 or more issues linked here and it will help us find some more information about the reasoning behind this change.
-->
None

### Manual testing scenarios (*)
<!---
    Please provide a set of unambiguous steps to test the proposed code change.
    Giving us manual testing scenarios will help with the processing and validation process.
-->
Just type errors in PHP. Should be clear by following the `\Magento\Catalog\Block\Product\ImageFactory::create` method. Additionally described in the description.

### Questions or comments
<!---
	If relevant, here you can ask questions or provide comments on your pull request for the reviewer
	For example if you need assistance with writing tests or would like some feedback on one of your development ideas
-->
Maybe better/other approaches:
- Stringify `$imageMiscParams['image_type']` to have an empty string
- Create default value

### Contribution checklist (*)
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] All automated tests passed successfully (all builds are green)
